### PR TITLE
Force tcl files to have lf line endings inside tclkit. 

### DIFF
--- a/kitsh/buildsrc/kitsh-0.0/installvfs.tcl
+++ b/kitsh/buildsrc/kitsh-0.0/installvfs.tcl
@@ -37,6 +37,9 @@ proc copy_file {srcfile destfile} {
 			set ifd [open $srcfile r]
 			set ofd [open $destfile w]
 
+			# Force tcl files to have lf line endings inside tclkit.
+			fconfigure $ofd -translation lf
+
 			set ret [fcopy $ifd $ofd]
 
 			close $ofd


### PR DESCRIPTION
Otherwise, fcopy would produce crlf if on Windows.

Files may be read directly using mk4tcl/uplevel commands without automatic \<newline> substitution.
\<newline> occur inside mk4vfs.tcl. The resulting error is silently suppressed, but leads to a not
functional access to the vfs like the one decribed here http://kitcreator.rkeene.org/fossil/tktview?name=3428b6ae06